### PR TITLE
Add docs, download multiple files, support Python 3, fix ffmpeg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then run the script, providing the name of this file with names and URLs:
 ```
 
 ## Acknowledgements
-Based on:
-* https://gist.github.com/alexeygrigorev/a1bc540925054b71e1a7268e50ad55cd
-* https://gist.github.com/brasno/25fe2d30a31b40fe98cc9f55cfb709ab
-* https://github.com/AbCthings/vimeo-audio-video
+Based on work of:
+* @alexeygrigorev: https://gist.github.com/alexeygrigorev/a1bc540925054b71e1a7268e50ad55cd
+* @brasno: https://gist.github.com/brasno/25fe2d30a31b40fe98cc9f55cfb709ab
+* @AbCthings: https://github.com/AbCthings/vimeo-audio-video

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For each video you want to download:
 1. Go to the Network tab.
 1. Right click on the `master.json` request, select Copy → Copy link address. An example of how such a URL could look like: `https://178skyfiregce-a.akamaihd.net/exp=1474107106~acl=%2F142089577%2F%2A~hmac=0d9becc441fc5385462d53bf59cf019c0184690862f49b414e9a2f1c5bafbe0d/142089577/video/426274424,426274425,426274423,426274422/master.json?base64_init=1`.
 
-Create a TSV file (can be done e. g. by copy-pasting from Google Sheets), where the first column is output file name (ending with `.mp4`) and the second is this URL to `master.json.
+Create a TSV file (can be done e. g. by copy-pasting from Google Sheets), where the first column is output file name (ending with `.mp4`) and the second is this URL to `master.json`.
 
 Then run the script, providing the name of this file with names and URLs:
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Download segmented videos from Vimeo
+
+## Install prerequisites
+
+Install ffmpeg and Python 3:
+* Debian/Ubuntu: `sudo apt install -y ffmpeg python3`
+* Mac OS X: `brew install ffmpeg python`
+
+Install Python tqdm module: `sudo python3 -m pip install --upgrade tqdm`
+
+## Instructions to download video
+For each video you want to download:
+1. Open the page containing the embedded video.
+1. Open development console (Chrome: F12).
+1. Go to the Network tab.
+1. Right click on the `master.json` request, select Copy → Copy link address. An example of how such a URL could look like: `https://178skyfiregce-a.akamaihd.net/exp=1474107106~acl=%2F142089577%2F%2A~hmac=0d9becc441fc5385462d53bf59cf019c0184690862f49b414e9a2f1c5bafbe0d/142089577/video/426274424,426274425,426274423,426274422/master.json?base64_init=1`.
+
+Create a TSV file (can be done e. g. by copy-pasting from Google Sheets), where the first column is output file name (ending with `.mp4`) and the second is this URL to `master.json.
+
+Then run the script, providing the name of this file with names and URLs:
+```bash
+./vimeo-autio-and-video.py -i names_urls.txt
+```
+
+## Acknowledgements
+Based on:
+* https://gist.github.com/alexeygrigorev/a1bc540925054b71e1a7268e50ad55cd
+* https://gist.github.com/brasno/25fe2d30a31b40fe98cc9f55cfb709ab
+* https://github.com/AbCthings/vimeo-audio-video

--- a/vimeo-audio-and-video.py
+++ b/vimeo-audio-and-video.py
@@ -1,110 +1,101 @@
-'''
-@brief download segmented videos from Vimeo
-@references https://gist.github.com/alexeygrigorev/a1bc540925054b71e1a7268e50ad55cd
-@references https://gist.github.com/brasno/25fe2d30a31b40fe98cc9f55cfb709ab
-@instructions 
-    1 Open the network tab in the inspector
-    2 Find the url of a request to the master.json file
-    3 Copy it here
-    4 Run the script
-'''
-
-# Import section
-import requests
+#!/usr/bin/env python3
+import argparse
 import base64
-from tqdm import tqdm
-import re
-import subprocess
 import os
+import re
+import requests
+import subprocess
+from tqdm import tqdm
 
-# Specify here the master.json file URL
-master_json_url = 'https://178skyfiregce-a.akamaihd.net/exp=1474107106~acl=%2F142089577%2F%2A~hmac=0d9becc441fc5385462d53bf59cf019c0184690862f49b414e9a2f1c5bafbe0d/142089577/video/426274424,426274425,426274423,426274422/master.json?base64_init=1'
+parser = argparse.ArgumentParser()
+parser.add_argument('-i', '--url-list', help='List of URL/filename pairs, delimited by tabs')
+args = parser.parse_args()
 
-# Specify here output file name
-filenameOutput = 'output.mp4'
+for line in open(args.url_list):
+    output_file, master_json_url = line.rstrip().split('\t')
+    print('\n\n\nProcessing %s' % output_file)
 
-# Extract some stuff
-base_url = master_json_url[:master_json_url.rfind('/', 0, -26) + 1]
-resp = requests.get(master_json_url)
-content = resp.json()
+    # Extract some stuff
+    base_url = master_json_url[:master_json_url.rfind('/', 0, -26) + 1]
+    resp = requests.get(master_json_url)
+    content = resp.json()
 
-# Video download here
-heights = [(i, d['height']) for (i, d) in enumerate(content['video'])]
-idx, _ = max(heights, key=lambda (_, h): h)
-video = content['video'][idx]
-video_base_url = base_url + video['base_url']
-print 'base url:', video_base_url
+    # Video download here
+    heights = [(i, d['height']) for (i, d) in enumerate(content['video'])]
+    idx = max(heights, key=lambda x: x[1])[0]
+    video = content['video'][idx]
+    video_base_url = base_url + video['base_url']
+    print('Base url:', video_base_url)
 
-filenameVideo = 'video_%s.mp4' % video['id']
-print 'saving VIDEO to %s' % filenameVideo
+    filenameVideo = 'video_%s.mp4' % video['id']
+    print('Saving VIDEO to %s' % filenameVideo)
 
-video_file = open(filenameVideo, 'wb')
+    video_file = open(filenameVideo, 'wb')
 
-init_segment = base64.b64decode(video['init_segment'])
-video_file.write(init_segment)
+    init_segment = base64.b64decode(video['init_segment'])
+    video_file.write(init_segment)
 
-for segment in tqdm(video['segments']):
-    segment_url = video_base_url + segment['url']
-    resp = requests.get(segment_url, stream=True)
-    if resp.status_code != 200:
-        print 'not 200!'
-        print resp
-        print segment_url
-        break
-    for chunk in resp:
-        video_file.write(chunk)
+    for segment in tqdm(video['segments']):
+        segment_url = video_base_url + segment['url']
+        resp = requests.get(segment_url, stream=True)
+        if resp.status_code != 200:
+            print('not 200!')
+            print(resp)
+            print(segment_url)
+            break
+        for chunk in resp:
+            video_file.write(chunk)
 
-video_file.flush()
-video_file.close()
+    video_file.flush()
+    video_file.close()
 
-# Audio download here
-bitrate = [(i, d['bitrate']) for (i, d) in enumerate(content['audio'])]
+    # Audio download here
+    bitrate = [(i, d['bitrate']) for (i, d) in enumerate(content['audio'])]
 
-print 'bitrate', bitrate
- 
-idx, _ = max(bitrate, key=lambda (_, h): h)
-audio = content['audio'][idx]
-audio_base_url = base_url + audio['base_url']
-print 'base url:', audio_base_url
+    print('Bitrate', bitrate)
 
-filenameAudio = 'audio_%s.mp4' % audio['id']
-print 'saving AUDIO to %s' % filenameAudio
+    idx = max(bitrate, key=lambda x: x[1])[0]
+    audio = content['audio'][idx]
+    audio_base_url = base_url + audio['base_url']
+    print('Base url:', audio_base_url)
 
-audio_file = open(filenameAudio, 'wb')
+    filenameAudio = 'audio_%s.mp4' % audio['id']
+    print('Saving AUDIO to %s' % filenameAudio)
 
-init_segment = base64.b64decode(audio['init_segment'])
-audio_file.write(init_segment)
+    audio_file = open(filenameAudio, 'wb')
 
-for segment in tqdm(audio['segments']):
-    segment_url = audio_base_url + segment['url']
-    segment_url = re.sub(r'/[a-zA-Z0-9_-]*/\.\./',r'/',segment_url.rstrip())
-    resp = requests.get(segment_url, stream=True)
-    if resp.status_code != 200:
-        print 'not 200!'
-        print resp
-        print segment_url
-        break
-    for chunk in resp:
-        audio_file.write(chunk)
+    init_segment = base64.b64decode(audio['init_segment'])
+    audio_file.write(init_segment)
 
-audio_file.flush()
-audio_file.close()
+    for segment in tqdm(audio['segments']):
+        segment_url = audio_base_url + segment['url']
+        segment_url = re.sub(r'/[a-zA-Z0-9_-]*/\.\./',r'/',segment_url.rstrip())
+        resp = requests.get(segment_url, stream=True)
+        if resp.status_code != 200:
+            print('not 200!')
+            print(resp)
+            print(segment_url)
+            break
+        for chunk in resp:
+            audio_file.write(chunk)
 
-# Combine audio and video here
-print('Combining video and audio...')
-cmd = 'ffmpeg -y -i '
-cmd += filenameAudio
-cmd += ' -i '
-cmd += filenameVideo
-cmd += ' -c:v copy -c:a aac '
-cmd += filenameOutput
-subprocess.call(cmd, shell=True)
-print('Mixing Done!')
+    audio_file.flush()
+    audio_file.close()
 
-# Delete the remaining single audio and video files
-os.remove(filenameAudio)
-os.remove(filenameVideo)
-print("Temporary files removed!")
+    # Combine audio and video here
+    print('Combining video and audio...')
+    cmd = 'ffmpeg -y -i '
+    cmd += filenameAudio
+    cmd += ' -i '
+    cmd += filenameVideo
+    cmd += ' ' + output_file
+    subprocess.call(cmd, shell=True)
+    print('Mixing Done!')
 
-# Log the conclusion of the operations
-print("*** VIDEO DOWNLOADED SUCCESSFULLY ***")
+    # Delete the remaining single audio and video files
+    os.remove(filenameAudio)
+    os.remove(filenameVideo)
+    print("Temporary files removed!")
+
+    # Log the conclusion of the operations
+    print("*** VIDEO DOWNLOADED SUCCESSFULLY ***")


### PR DESCRIPTION
Hi, thanks for writing this awesome script! It really came in handy when I needed to download some embedded Vimeo videos. I made a few modifications for my own use, maybe you'd like to merge them as well:
* Added `README.md` so that a less technically inclined person could also use the script.
* Added support for downloading multiple files by specifying a single TSV file with (filename, URL) pairs as input.
* Fixed some statements (prints and lambdas) to be able to run on Python 3. As far as I'm aware, these changes should not break Python 2 compatibility either.
* Removed the `-c:v copy -c:a aac` flags from ffmpeg command line. The issue I found is that for some videos, when you try to use `copy` for video, it unfortunately results in a broken output file which cannot be played past a certain point. I suspect that this is because M4V streams cannot be always concatenated smoothly. Maybe the issue happens when the split happens between key frames or something. Anyway, without those options ffmpeg will just recode both audio and video in a sensible way. Even though this will take significantly longer (though still not longer than the video's runtime, even on low performance machines), this will guarantee the output files will not be broken.